### PR TITLE
refactor(query): fix number parsing in planParamsToQuery

### DIFF
--- a/packages/core-utils/src/__tests__/__snapshots__/query.js.snap
+++ b/packages/core-utils/src/__tests__/__snapshots__/query.js.snap
@@ -2,6 +2,7 @@
 
 exports[`query planParamsToQuery should parse a depart at query 1`] = `
 Object {
+  "bannedRoutes": "897ABC",
   "companies": "",
   "date": "2019-10-31",
   "departArrive": "DEPART",

--- a/packages/core-utils/src/__tests__/query.js
+++ b/packages/core-utils/src/__tests__/query.js
@@ -6,6 +6,7 @@ describe("query", () => {
       expect(
         planParamsToQuery({
           arriveBy: "false",
+          bannedRoutes: "897ABC",
           companies: "",
           date: "2019-10-31",
           fromPlace:

--- a/packages/core-utils/src/query.js
+++ b/packages/core-utils/src/query.js
@@ -210,8 +210,14 @@ export function planParamsToQuery(params, config) {
         query.time = params.time || getCurrentTime(config);
         break;
       default: {
-        const maybeNumber = parseFloat(params[key]);
-        query[key] = Number.isNaN(maybeNumber) ? params[key] : maybeNumber;
+        const maybeNumber = Number(params[key]);
+        // If the param value is an empty string literal and is not a number,
+        // use string value. Else, use parsed number value.
+        // See https://github.com/opentripplanner/otp-ui/issues/50
+        query[key] =
+          params[key] === "" || Number.isNaN(maybeNumber)
+            ? params[key]
+            : maybeNumber;
         break;
       }
     }


### PR DESCRIPTION
@evansiroky, here's a possible fix for https://github.com/opentripplanner/otp-ui/pull/57