### PR TITLE
Add knob to story; update comment

### DIFF
--- a/packages/vehicle-rental-overlay/src/VehicleRentalOverlay.story.js
+++ b/packages/vehicle-rental-overlay/src/VehicleRentalOverlay.story.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { CircleMarker } from "react-leaflet";
 import { action } from "@storybook/addon-actions";
+import { boolean } from "@storybook/addon-knobs";
 
 import VehicleRentalOverlay from ".";
 import bikeRentalStations from "../__mocks__/bike-rental-stations.json";
@@ -245,15 +246,21 @@ export const RentalBicycles = () => (
   />
 );
 
-export const RentalBicyclesVisibleOnMount = () => (
-  <ZoomControlledMapWithVehicleRentalOverlay
-    companies={["BIKETOWN"]}
-    mapSymbols={bikeMapSymbols}
-    refreshVehicles={action("refresh bicycles")}
-    stations={bikeRentalStations}
-    visible
-  />
-);
+export const RentalBicyclesVisibilityControlledByKnob = () => {
+  const isOverlayVisible = boolean(
+    "Toggle visibility of vehicle rental overlay",
+    true
+  );
+  return (
+    <ZoomControlledMapWithVehicleRentalOverlay
+      companies={["BIKETOWN"]}
+      mapSymbols={bikeMapSymbols}
+      refreshVehicles={action("refresh bicycles")}
+      stations={bikeRentalStations}
+      visible={isOverlayVisible}
+    />
+  );
+};
 
 export const RentalBicyclesUsingNewSymbolsProp = () => (
   <ZoomControlledMapWithVehicleRentalOverlay

--- a/packages/vehicle-rental-overlay/src/index.js
+++ b/packages/vehicle-rental-overlay/src/index.js
@@ -152,7 +152,8 @@ class VehicleRentalOverlay extends MapLayer {
     const { companies, mapSymbols, stations, visible } = this.props;
     // Render an empty FeatureGroup if the rental vehicles should not be visible
     // on the map. Otherwise previous stations may still be shown due to some
-    // react-leaflet internals, maybe?
+    // react-leaflet internals, maybe? Also, do not return null because that will
+    // prevent the overlay from appearing in the layer controls.
     if (!visible) {
       return <FeatureGroup />;
     }


### PR DESCRIPTION
@evansiroky, I don't fully grasp the need for the `LeafletLayerControlInterface` class you added in https://github.com/opentripplanner/otp-ui/pull/267. I do think adding a knob might be helpful for displaying that the `visible` prop does in fact allow the visibility to be controlled externally.