### PR TITLE
refactor(base-map): Simplify map layer selector keyboard accessibility.

### DIFF
--- a/packages/base-map/src/index.tsx
+++ b/packages/base-map/src/index.tsx
@@ -151,32 +151,9 @@ const BaseMap = ({
         <Styled.LayerSelector
           className="filter-group"
           id="filter-group"
+          onBlur={() => setFakeHover(false)}
           onFocus={() => setFakeHover(true)}
-          onBlur={e => {
-            // Identify the first and last item in the list
-            // by doing this, we can determine if we should close the list when
-            // we leave it via keyboard
-
-            // Every list item fires a blur event, so we need to ignore some of them
-            if (typeof toggleableLayers === "object") {
-              const firstId =
-                typeof baseLayer === "object"
-                  ? "first-layer"
-                  : toggleableLayers[0].id;
-
-              const lastId =
-                toggleableLayers && toggleableLayers?.length > 0
-                  ? toggleableLayers[toggleableLayers.length - 1].id
-                  : baseLayer[baseLayer.length - 1];
-              if (e.target.id === firstId || e.target.id === lastId) {
-                setFakeHover(false);
-              }
-            }
-          }}
-          onTouchEnd={() => {
-            setFakeHover(true);
-          }}
-          tabIndex={0}
+          onTouchEnd={() => setFakeHover(true)}
         >
           <ul
             className={`layers-list ${fakeMobileHover && "fake-mobile-hover"}`}
@@ -185,7 +162,7 @@ const BaseMap = ({
               typeof baseLayer === "object" &&
               baseLayer.map((layer: string, index: number) => {
                 return (
-                  <li key={index} id={index === 0 ? "first-layer" : ""}>
+                  <li key={index}>
                     {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
                     <label>
                       <input

--- a/packages/base-map/src/styled.ts
+++ b/packages/base-map/src/styled.ts
@@ -84,7 +84,10 @@ export const LayerSelector = styled.aside`
     right: 0;
 
     label {
-      display: none;
+      display: block;
+      height: 0;
+      overflow: hidden;
+      width: 0;
 
       input {
         margin-right: 1ch;
@@ -101,6 +104,9 @@ export const LayerSelector = styled.aside`
     &.fake-mobile-hover {
       label {
         display: block;
+        height: unset;
+        overflow: unset;
+        width: unset;
       }
       &::after {
         display: none;


### PR DESCRIPTION
This simplifies and improves the keyboard handling, and the selector is hidden when focus moves out of the layer selector. No use of ids.

A couple of unintended things with this PR:
- The layer check boxes and radio buttons are visible at all times to screen readers
- When tabbing in reverse order, the last layer check box or radio will get the focus.
- The changes (still) don't work on Safari.
