### PR TITLE
Itinerary a11y fixes transit

### DIFF
--- a/packages/itinerary-body/i18n/en-US.yml
+++ b/packages/itinerary-body/i18n/en-US.yml
@@ -89,10 +89,6 @@ otpUi:
       walk: by walking
     viewOnMap: View on map
   TransitLegBody:
-    accessibilityTransitLegDesc: "Ride {routeName} {headsign, select,
-      true {to {legHeadsign}}
-      other {}
-      }"
     disembarkAt: Disembark at {legDestination}
     fromLocation: "from {location}"
     arriveAt: "Arrive at {place}"
@@ -109,6 +105,7 @@ otpUi:
     legDetails: Leg details
     expandDetails: (Expand details)
     operatedBy: Service operated by {agencyLink}
+    ride: Ride
     rideDurationAndStops: "Ride {duration}{numStops, plural, =1 {} other { / # stops}}"
     routeDescription: "{routeName} <toPrefix>to</toPrefix> {headsign}"
     stopId: Stop ID {stopId}

--- a/packages/itinerary-body/i18n/en-US.yml
+++ b/packages/itinerary-body/i18n/en-US.yml
@@ -89,10 +89,10 @@ otpUi:
       walk: by walking
     viewOnMap: View on map
   TransitLegBody:
-    accessibilityTransitLegDesc: " Ride {routeName} {mode} {headsign, select,
+    accessibilityTransitLegDesc: "Ride {routeName} {headsign, select,
       true {to {legHeadsign}}
       other {}
-      } from {place}"
+      }"
     disembarkAt: Disembark at {legDestination}
     fromLocation: "from {location}"
     arriveAt: "Arrive at {place}"
@@ -104,7 +104,6 @@ otpUi:
       tomorrow: Tomorrow
       yesterday: Yesterday
     alertsHeader: "{alertCount, plural, =1 {# alert} other {# alerts}}"
-    departAt: Depart at
     fare: "Fare: {fare}"
     zoomToLeg: (Zoom to leg on map)
     legDetails: Leg details

--- a/packages/itinerary-body/src/AccessLegBody/access-leg-summary.tsx
+++ b/packages/itinerary-body/src/AccessLegBody/access-leg-summary.tsx
@@ -31,6 +31,7 @@ export default function AccessLegSummary({
             </S.LegIconContainer>
           )}
         </S.LegIconAndRouteShortName>
+        <S.InvisibleAdditionalDetails> - </S.InvisibleAdditionalDetails>
         <AccessLegDescription config={config} leg={leg} />
         <S.LegClickableButton onClick={onSummaryClick}>
           <S.InvisibleAdditionalDetails>

--- a/packages/itinerary-body/src/ItineraryBody/place-row.tsx
+++ b/packages/itinerary-body/src/ItineraryBody/place-row.tsx
@@ -10,7 +10,6 @@ import TransitLegBody from "../TransitLegBody";
 import AccessibilityRating from "./accessibility-rating";
 import { PlaceRowProps } from "../types";
 import { defaultMessages } from "../util";
-import { getSummaryMode } from "../defaults/access-leg-description";
 
 /*
   TODO: Wondering if it's possible for us to destructure the time
@@ -25,7 +24,6 @@ export default function PlaceRow({
   diagramVisible,
   fare,
   followsTransit,
-  formattedModesByLeg,
   frameLeg,
   isDestination,
   lastLeg,
@@ -113,29 +111,13 @@ export default function PlaceRow({
       </S.TimeColumn>
       <S.InvisibleAdditionalDetails>
         {!isDestination ? (
-          leg.transitLeg ? (
-            <FormattedMessage
-              description="Invisible description of transit leg for screen readers"
-              id="otpUi.TransitLegBody.accessibilityTransitLegDesc"
-              values={{
-                headsign: !!leg.headsign,
-                legHeadsign: leg.headsign,
-                mode: formattedModesByLeg
-                  ? formattedModesByLeg[legIndex]
-                  : getSummaryMode(leg, intl),
-                place: formattedPlace(leg.from),
-                routeName: leg.routeShortName || leg.routeLongName
-              }}
-            />
-          ) : (
-            <FormattedMessage
-              description="Add starting location for access legs"
-              id="otpUi.TransitLegBody.fromLocation"
-              values={{
-                location: formattedPlace(leg.from)
-              }}
-            />
-          )
+          <FormattedMessage
+            description="Add starting location for access legs"
+            id="otpUi.TransitLegBody.fromLocation"
+            values={{
+              location: formattedPlace(leg.from)
+            }}
+          />
         ) : (
           <FormattedMessage
             id="otpUi.TransitLegBody.arriveAt"

--- a/packages/itinerary-body/src/TransitLegBody/index.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/index.tsx
@@ -186,32 +186,35 @@ class TransitLegBody extends Component<Props, State> {
           {/* The Route Icon/Name Bar */}
           <S.LegClickable>
             <S.LegDescription>
-              <S.InvisibleAdditionalDetails>
-                {/* Include the screen reader text here, knowing that the RouteDescription portion can be overriden. */}
-                <FormattedMessage
-                  description="Invisible description of transit leg for screen readers"
-                  id="otpUi.TransitLegBody.accessibilityTransitLegDesc"
-                  values={{
-                    headsign: !!leg.headsign,
-                    legHeadsign: leg.headsign,
-                    routeName: leg.routeShortName || leg.routeLongName
-                  }}
-                />
-                {". " /* TODO: conjunctions. */}
-                <FormattedMessage
-                  // TODO: Accommodate interline itineraries with "Stay on board" instructions.
-                  id="otpUi.TransitLegBody.disembarkAt"
-                  values={{
-                    legDestination
-                  }}
-                />
-              </S.InvisibleAdditionalDetails>
-              <span aria-hidden>
+              <span>
+                <S.InvisibleAdditionalDetails>
+                  <FormattedMessage
+                    defaultMessage={
+                      defaultMessages["otpUi.TransitLegBody.ride"]
+                    }
+                    description="Prompt to ride a transit vehicle."
+                    id="otpUi.TransitLegBody.ride"
+                  />
+                </S.InvisibleAdditionalDetails>
                 <RouteDescription
                   leg={leg}
                   LegIcon={LegIcon}
                   transitOperator={transitOperator}
                 />
+                <S.InvisibleAdditionalDetails>
+                  {". " /* TODO: conjunctions. */}
+                  <FormattedMessage
+                    // TODO: Accommodate interline itineraries with "Stay on board" instructions.
+                    defaultMessage={
+                      defaultMessages["otpUi.TransitLegBody.disembarkAt"]
+                    }
+                    description="Prompt to exit a transit vehicle."
+                    id="otpUi.TransitLegBody.disembarkAt"
+                    values={{
+                      legDestination
+                    }}
+                  />
+                </S.InvisibleAdditionalDetails>
               </span>
               <S.LegClickableButton onClick={this.onSummaryClick}>
                 <S.InvisibleAdditionalDetails>

--- a/packages/itinerary-body/src/TransitLegBody/index.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/index.tsx
@@ -182,18 +182,30 @@ class TransitLegBody extends Component<Props, State> {
     return (
       <>
         {TransitLegSubheader && <TransitLegSubheader leg={leg} />}
-        <S.InvisibleAdditionalDetails>
-          <FormattedMessage
-            id="otpUi.TransitLegBody.disembarkAt"
-            values={{
-              legDestination
-            }}
-          />
-        </S.InvisibleAdditionalDetails>
         <S.LegBody>
           {/* The Route Icon/Name Bar */}
           <S.LegClickable>
             <S.LegDescription>
+              <S.InvisibleAdditionalDetails>
+                {/* Include the screen reader text here, knowing that the RouteDescription portion can be overriden. */}
+                <FormattedMessage
+                  description="Invisible description of transit leg for screen readers"
+                  id="otpUi.TransitLegBody.accessibilityTransitLegDesc"
+                  values={{
+                    headsign: !!leg.headsign,
+                    legHeadsign: leg.headsign,
+                    routeName: leg.routeShortName || leg.routeLongName
+                  }}
+                />
+                {". " /* TODO: conjunctions. */}
+                <FormattedMessage
+                  // TODO: Accommodate interline itineraries with "Stay on board" instructions.
+                  id="otpUi.TransitLegBody.disembarkAt"
+                  values={{
+                    legDestination
+                  }}
+                />
+              </S.InvisibleAdditionalDetails>
               <span aria-hidden>
                 <RouteDescription
                   leg={leg}

--- a/packages/itinerary-body/src/TransitLegBody/index.tsx
+++ b/packages/itinerary-body/src/TransitLegBody/index.tsx
@@ -188,6 +188,7 @@ class TransitLegBody extends Component<Props, State> {
             <S.LegDescription>
               <span>
                 <S.InvisibleAdditionalDetails>
+                  {" - "}
                   <FormattedMessage
                     defaultMessage={
                       defaultMessages["otpUi.TransitLegBody.ride"]
@@ -202,7 +203,7 @@ class TransitLegBody extends Component<Props, State> {
                   transitOperator={transitOperator}
                 />
                 <S.InvisibleAdditionalDetails>
-                  {". " /* TODO: conjunctions. */}
+                  {" - "}
                   <FormattedMessage
                     // TODO: Accommodate interline itineraries with "Stay on board" instructions.
                     defaultMessage={

--- a/packages/itinerary-body/src/defaults/access-leg-description.tsx
+++ b/packages/itinerary-body/src/defaults/access-leg-description.tsx
@@ -33,15 +33,15 @@ export function getSummaryMode(leg: Leg, intl: IntlShape): string {
       return leg.hailedCar
         ? intl.formatMessage({
             defaultMessage:
-              defaultMessages["otpUi.AccessLegBody.summaryMode.carDrive"],
-            description: "Drive somewhere",
-            id: "otpUi.AccessLegBody.summaryMode.carDrive"
-          })
-        : intl.formatMessage({
-            defaultMessage:
               defaultMessages["otpUi.AccessLegBody.summaryMode.carHail"],
             description: "Ride in a car/taxi to somewhere",
             id: "otpUi.AccessLegBody.summaryMode.carHail"
+          })
+        : intl.formatMessage({
+            defaultMessage:
+              defaultMessages["otpUi.AccessLegBody.summaryMode.carDrive"],
+            description: "Drive somewhere",
+            id: "otpUi.AccessLegBody.summaryMode.carDrive"
           });
     case "MICROMOBILITY":
     case "MICROMOBILITY_RENT":

--- a/packages/itinerary-body/src/defaults/time-column-content.tsx
+++ b/packages/itinerary-body/src/defaults/time-column-content.tsx
@@ -1,10 +1,7 @@
 import React, { ReactElement } from "react";
-import { FormattedMessage, FormattedTime } from "react-intl";
+import { FormattedTime } from "react-intl";
 
 import { TimeColumnContentProps } from "../types";
-
-import * as S from "../styled";
-import { defaultMessages } from "../util";
 
 /**
  * This is the default component for displaying the time with the specified format
@@ -15,20 +12,5 @@ export default function TimeColumnContent({
   leg
 }: TimeColumnContentProps): ReactElement {
   const time = isDestination ? leg.endTime : leg.startTime;
-  return (
-    time && (
-      <>
-        {!isDestination && (
-          <S.InvisibleAdditionalDetails>
-            <FormattedMessage
-              defaultMessage={defaultMessages["otpUi.TransitLegBody.departAt"]}
-              description="Introduces the departure time to screenreaders"
-              id="otpUi.TransitLegBody.departAt"
-            />
-          </S.InvisibleAdditionalDetails>
-        )}
-        <FormattedTime value={time} />
-      </>
-    )
-  );
+  return time && <FormattedTime value={time} />;
 }

--- a/packages/itinerary-body/src/stories/LegIconWithA11y.tsx
+++ b/packages/itinerary-body/src/stories/LegIconWithA11y.tsx
@@ -1,0 +1,22 @@
+import coreUtils from "@opentripplanner/core-utils";
+import { ClassicLegIcon } from "@opentripplanner/icons";
+import { Leg } from "@opentripplanner/types";
+import React, { ReactElement } from "react";
+
+interface Props {
+  leg: Leg;
+  // plus other props not listed here.
+}
+
+/**
+ * For illustration only. Component where the transit leg icons have an (untranslated) aria-label.
+ */
+const LegIconWithA11y = (props: Props): ReactElement => {
+  const { leg } = props;
+  const { mode } = leg;
+  const ariaLabel = coreUtils.itinerary.isTransit(mode) ? mode : undefined;
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  return <ClassicLegIcon {...props} aria-label={ariaLabel} />;
+};
+
+export default LegIconWithA11y;

--- a/packages/itinerary-body/src/stories/OtpRrItineraryBody.story.tsx
+++ b/packages/itinerary-body/src/stories/OtpRrItineraryBody.story.tsx
@@ -1,4 +1,3 @@
-import { ClassicLegIcon } from "@opentripplanner/icons";
 import { Itinerary } from "@opentripplanner/types";
 import React, { ReactElement } from "react";
 
@@ -14,6 +13,7 @@ import { isRunningJest } from "../../../../.storybook/react-intl";
 import { TimeColumnContentProps } from "../types";
 
 import ItineraryBodyDefaultsWrapper from "./itinerary-body-defaults-wrapper";
+import LegIconWithA11y from "./LegIconWithA11y";
 
 // import mock itinaries. These are all trip plan outputs from OTP.
 const bikeOnlyItinerary = require("../__mocks__/itineraries/bike-only.json");
@@ -65,7 +65,7 @@ function OtpRRItineraryBodyWrapper({
       alwaysCollapseAlerts={alwaysCollapseAlerts}
       formattedModesByLeg={formattedModesByLeg}
       itinerary={itinerary}
-      LegIcon={ClassicLegIcon}
+      LegIcon={LegIconWithA11y}
       LineColumnContent={OtpRRLineColumnContent}
       PlaceName={OtpRRPlaceName}
       RouteDescription={OtpRRRouteDescription}


### PR DESCRIPTION
PR to improve some of the itinerary descriptions for screen readers, including passing an ARIA label for transit modes (shown in storybook as an illustration - this give the implementation the responsibility of providing the correct screen reader text for each mode.)