### PR TITLE
fix(MetroModeSelector): Restrict hover to non-keyboard interaction.

### DIFF
--- a/packages/trip-form/src/MetroModeSelector/index.tsx
+++ b/packages/trip-form/src/MetroModeSelector/index.tsx
@@ -365,20 +365,23 @@ export default function ModeSelector({
   onSettingsUpdate,
   onToggleModeButton
 }: Props): ReactElement {
-  const [keyboardPopup, setKeyboardPopup] = useState(null);
+  // State that holds the id of the active mode combination popup that was triggered via keyboard.
+  // It is used to enable/disable hover effects to avoid keyboard focus being stolen
+  // and overlapping popups on mouse hover.
+  const [itemWithKeyboard, setItemWithKeyboard] = useState<string>(null);
   return (
     <ModeBar className="metro-mode-selector">
       <legend>{label}</legend>
       {modeButtons.map(combination => (
         <ModeButton
           id={combination.key}
-          itemWithKeyboard={keyboardPopup}
+          itemWithKeyboard={itemWithKeyboard}
           key={combination.label}
           modeButton={combination}
           onPopupClose={useCallback(() => {
-            setKeyboardPopup(null);
-          }, [setKeyboardPopup])}
-          onPopupKeyboardExpand={setKeyboardPopup}
+            setItemWithKeyboard(null);
+          }, [setItemWithKeyboard])}
+          onPopupKeyboardExpand={setItemWithKeyboard}
           onSettingsUpdate={onSettingsUpdate}
           onToggle={useCallback(() => {
             onToggleModeButton(combination.key);


### PR DESCRIPTION
Changes to improve keyboard focus handling:
- Hover is allowed and popup will show as normal when no popup has been triggered via keyboard (using the "invisible" expanding buttons). Focus cues will not appear on the mode labels.
- When a popup is triggered using the keyboard, no other popups can be opened during that time. The popup can still be dismissed using ESC or by clicking away. If using ESC, focus cues will be shown in the original label.