### PR TITLE
Remove calories from trip details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ Handful of cleanup PRs:
 
 - [printable-itinerary](http://www.opentripplanner.org/otp-ui/?path=/story/printableitinerary--itinerarybody-with-walk-only-itinerary) adds a component for rendering an OTP itinerary formatted for printing on 8.5x11 paper. Resolves issue [#38](https://github.com/opentripplanner/otp-ui/issues/38)
 
-- [trip-details](http://www.opentripplanner.org/otp-ui/?path=/story/tripdetails--tripdetails-with-tnc-transit-itinerary) adds a component to render cost, date/time and calories based on an OTP itinerary.
+- [trip-details](http://www.opentripplanner.org/otp-ui/?path=/story/tripdetails--tripdetails-with-tnc-transit-itinerary) adds a component to render cost and date/time based on an OTP itinerary.
 
 ### Changes
 

--- a/packages/core-utils/src/itinerary.ts
+++ b/packages/core-utils/src/itinerary.ts
@@ -410,28 +410,6 @@ export function getTNCLocation(leg: Leg, type: string): string {
   return `${location.lat.toFixed(5)},${location.lon.toFixed(5)}`;
 }
 
-export function calculatePhysicalActivity(
-  itinerary: ItineraryOnlyLegsRequired
-): {
-  bikeDuration: number;
-  caloriesBurned: number;
-  walkDuration: number;
-} {
-  let walkDuration = 0;
-  let bikeDuration = 0;
-  itinerary.legs.forEach(leg => {
-    if (leg.mode.startsWith("WALK")) walkDuration += leg.duration;
-    if (leg.mode.startsWith("BICYCLE")) bikeDuration += leg.duration;
-  });
-  const caloriesBurned =
-    (walkDuration / 3600) * 280 + (bikeDuration / 3600) * 290;
-  return {
-    bikeDuration,
-    caloriesBurned,
-    walkDuration
-  };
-}
-
 /**
  * For an itinerary, calculates the TNC fares and returns an object with
  * these values and currency info.

--- a/packages/trip-details/__mocks__/custom-english-messages.yml
+++ b/packages/trip-details/__mocks__/custom-english-messages.yml
@@ -1,14 +1,14 @@
-# Example used to overwrite a subset of the messages from /i18n/en-US.yml.
 otpUi:
   TripDetails:
-    caloriesDescription: "Walking <strong>{walkMinutes}</strong> minute(s) and biking <strong>{bikeMinutes}</strong> minute(s) will consume {calories} Calories."
-    departure: "<strong>Leave</strong> at <strong>{departureDate, time, short}</strong> on <strong>{departureDate, date, long}</strong>"
-    title: "Custom Trip Details Title"
-    tncFare: "Pay <strong>{minTNCFare}-{maxTNCFare}</strong> to {companies}"
+    departure: >-
+      <strong>Leave</strong> at <strong>{departureDate, time, short}</strong> on
+      <strong>{departureDate, date, long}</strong>
     fareDetailsHeaders:
-      regular: "Regular"
-      youth: "Youth"
-      senior: "Senior"
-      cash: "Cash"
-      electronic: "ORCA"
-      special: "LIFT"
+      cash: Cash
+      electronic: ORCA
+      regular: Regular
+      senior: Senior
+      special: LIFT
+      youth: Youth
+    title: Custom Trip Details Title
+    tncFare: Pay <strong>{minTNCFare}-{maxTNCFare}</strong> to {companies}

--- a/packages/trip-details/i18n/en-US.yml
+++ b/packages/trip-details/i18n/en-US.yml
@@ -1,12 +1,5 @@
 otpUi:
   TripDetails:
-    calories: "Calories Burned: <strong>{calories, number, ::.}</strong>"
-    caloriesDescription: >
-      Calories burned is based on <strong>{walkMinutes, plural, one {# minute}
-      other {# minutes}}</strong> spent walking and <strong>{bikeMinutes,
-      plural, one {# minute} other {# minutes}}</strong> spent biking during
-      this trip. Adapted from <dietaryLink>Dietary Guidelines for Americans
-      2005, page 16, Table 4</dietaryLink>.
     co2: "CO₂ Emitted: <strong>{co2}</strong>"
     co2description: >-
       CO₂ intensity is calculated by multiplying the distance of each leg of a

--- a/packages/trip-details/i18n/es.yml
+++ b/packages/trip-details/i18n/es.yml
@@ -1,12 +1,5 @@
 otpUi:
   TripDetails:
-    calories: "Calorías quemadas: <strong>{calories, number, ::.}</strong>"
-    caloriesDescription: >
-      Las calorías quemadas se basan en <strong>{walkMinutes, plural, one {#
-      minuto} other {# minutos}}</strong> de caminata y <strong>{bikeMinutes,
-      plural, one {# minuto} other {# minutos}}</strong> en bicicleta durante
-      este viaje. Adaptado del <dietaryLink>Dietary Guidelines for Americans
-      2005, page 16, Table 4</dietaryLink>.
     co2: "CO₂ emitido: <strong>{co2}</strong>"
     co2description: >-
       La intensidad de CO₂ se calcula multiplicando la distancia de cada tramo

--- a/packages/trip-details/i18n/fr.yml
+++ b/packages/trip-details/i18n/fr.yml
@@ -1,13 +1,5 @@
 otpUi:
   TripDetails:
-    calories: "Calories dépensées : <strong>{calories, number, ::.}</strong>"
-    caloriesDescription: >
-      La dépense calorique est calculée sur la base de {walkMinutes, plural, one
-      {<strong># minute</strong> effectuée} other {<strong># minutes</strong>
-      effectuées}} à pied et {bikeMinutes, plural, one {<strong>#
-      minute</strong> effectuée} other {<strong># minutes</strong> effectuées}}
-      en vélo sur ce trajet. (d'après <dietaryLink>Dietary Guidelines for
-      Americans 2005, page 16, Table 4</dietaryLink>)
     co2: "CO₂ émis : <strong>{co2}</strong>"
     co2description: >-
       L'intensité carbone est calculée en multipliant la distance de chaque

--- a/packages/trip-details/i18n/ko.yml
+++ b/packages/trip-details/i18n/ko.yml
@@ -1,11 +1,5 @@
 otpUi:
   TripDetails:
-    calories: "소모 칼로리: <strong>{calories, number, ::.}</strong>"
-    caloriesDescription: >
-      소모된 칼로리는 이 트립에서 <strong>{walkMinutes}분 동안 </strong>걷고<strong>
-      <strong>{bikeMinutes}분</strong> 동안 자전거를 탄 것을 기준으로 합니다.
-      <dietaryLink>Dietary Guidelines for Americans 2005, 16 페이지, 표
-      4</dietaryLink> 적용.
     co2: "CO₂ 배출: <strong>{co2}</strong>"
     co2description: >-
       CO₂ 강도는 각 모드의 CO₂ 강도를 트립에서 각 다리가 걸은 거리를 곱하여 계산됩니다. 각 모드의 CO₂ 강도는 <link>이

--- a/packages/trip-details/i18n/nb_NO.yml
+++ b/packages/trip-details/i18n/nb_NO.yml
@@ -2,4 +2,3 @@ otpUi:
   TripDetails:
     fareDetailsHeaders:
       cash: Kontanter
-    calories: 'Forbrente kalorier: <strong>{calories, number, ::.}</strong>'

--- a/packages/trip-details/i18n/vi.yml
+++ b/packages/trip-details/i18n/vi.yml
@@ -1,11 +1,5 @@
 otpUi:
   TripDetails:
-    calories: "Calo bị đốt cháy: <strong>{calories, number, ::.}</strong>"
-    caloriesDescription: >
-      Lượng calo bị đốt cháy dựa trên <strong>{walkMinutes} phút</strong> đi bộ
-      và <strong>{bikeMinutes} phút</strong> dành cho chuyến đi xe đạp trong
-      chuyến đi này. Phỏng theo <dietaryLink>Dietary Guidelines for Americans
-      2005, trang 16, hình ảnh 4</dietaryLink>.
     co2: "CO₂ thải ra: <strong>{co2}</strong>"
     co2description: >-
       Nồng độ CO₂ được tính bằng cách nhân khoảng cách của mỗi chặng của một

--- a/packages/trip-details/i18n/zh_Hans.yml
+++ b/packages/trip-details/i18n/zh_Hans.yml
@@ -1,10 +1,5 @@
 otpUi:
   TripDetails:
-    calories: "卡路里消耗: <strong>{calories, number, ::.}</strong>"
-    caloriesDescription: >
-      燃烧的卡路里是根据这次旅行中的 <strong>{walkMinutes}分钟</strong> 步行和
-      <strong>{bikeMinutes}分钟</strong> 骑自行车计算的. 改编自< <dietaryLink>Dietary
-      Guidelines for Americans 2005, 页16, 图片4</dietaryLink>.
     co2: "排放的二氧化碳: <strong>{co2}</strong>"
     co2description: CO₂ 强度的计算方法是将行程的每条腿的距离乘以每种模式的 CO₂ 强度。 每种模式的二氧化碳强度来自<link>此电子表格</link>。
     departure: >-

--- a/packages/trip-details/src/TripDetails.story.tsx
+++ b/packages/trip-details/src/TripDetails.story.tsx
@@ -13,7 +13,6 @@ import styled from "styled-components";
 import TripDetails, { FareLegTable } from ".";
 import * as TripDetailsClasses from "./styled";
 import {
-  CaloriesDetailsProps,
   DepartureDetailsProps,
   FareDetailsProps,
   FareTableLayout,
@@ -210,17 +209,6 @@ const CustomDepartureDetails = ({
   </>
 );
 
-const CustomCaloriesDetails = ({
-  bikeSeconds,
-  calories,
-  walkSeconds
-}: CaloriesDetailsProps): ReactElement => (
-  <>
-    Custom message about {calories} calories burned,
-    {walkSeconds} seconds and {bikeSeconds} seconds.
-  </>
-);
-
 /**
  * Create a template component for each TripDetails story.
  * A Component argument is passed. Once bound,
@@ -232,7 +220,6 @@ function createTripDetailsTemplate(
 ): ComponentStory<typeof TripDetails> {
   const TripDetailsTemplate = (
     {
-      CaloriesDetails,
       DepartureDetails,
       FareDetails,
       fareDetailsLayout,
@@ -249,7 +236,6 @@ function createTripDetailsTemplate(
       : {};
     return (
       <Component
-        CaloriesDetails={CaloriesDetails}
         DepartureDetails={DepartureDetails}
         FareDetails={FareDetails}
         fareDetailsLayout={fareDetailsLayout}
@@ -377,7 +363,6 @@ export const TncTransitItinerary = makeStory(
 
 export const TncTransitItineraryWithCustomMessages = makeStory(
   {
-    CaloriesDetails: CustomCaloriesDetails,
     defaultFareKey: "electronicRegular",
     DepartureDetails: CustomDepartureDetails,
     itinerary: tncTransitTncItinerary

--- a/packages/trip-details/src/index.tsx
+++ b/packages/trip-details/src/index.tsx
@@ -3,7 +3,6 @@ import coreUtils from "@opentripplanner/core-utils";
 import React, { ReactElement } from "react";
 import { FormattedMessage, FormattedNumber } from "react-intl";
 import { CalendarAlt } from "@styled-icons/fa-solid/CalendarAlt";
-import { Heartbeat } from "@styled-icons/fa-solid/Heartbeat";
 import { MoneyBillAlt } from "@styled-icons/fa-solid/MoneyBillAlt";
 import { Leaf } from "@styled-icons/fa-solid/Leaf";
 import { Route } from "@styled-icons/fa-solid/Route";
@@ -13,11 +12,7 @@ import TripDetail from "./trip-detail";
 import FareLegTable from "./fare-table";
 import { boldText, renderFare } from "./utils";
 
-import {
-  CaloriesDetailsProps,
-  TransitFareProps,
-  TripDetailsProps
-} from "./types";
+import { TransitFareProps, TripDetailsProps } from "./types";
 
 // Load the default messages.
 import defaultEnglishMessages from "../i18n/en-US.yml";
@@ -28,21 +23,6 @@ import defaultEnglishMessages from "../i18n/en-US.yml";
 // - the yaml loader for jest returns messages with flattened ids.
 const defaultMessages: Record<string, string> = flatten(defaultEnglishMessages);
 
-/**
- * Helper function to specify the link to dietary table.
- */
-function dietaryLink(contents: ReactElement): ReactElement {
-  return (
-    <a
-      href="https://health.gov/dietaryguidelines/dga2005/document/html/chapter3.htm#table4"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      {contents}
-    </a>
-  );
-}
-
 function CO2DescriptionLink(contents: ReactElement): ReactElement {
   return (
     <a
@@ -52,31 +32,6 @@ function CO2DescriptionLink(contents: ReactElement): ReactElement {
     >
       {contents}
     </a>
-  );
-}
-
-/**
- * Default rendering if no component is provided for the CaloriesDetails
- * slot in the TripDetails component.
- */
-function DefaultCaloriesDetails({
-  bikeSeconds,
-  calories,
-  walkSeconds
-}: CaloriesDetailsProps): ReactElement {
-  return (
-    <FormattedMessage
-      defaultMessage={defaultMessages["otpUi.TripDetails.caloriesDescription"]}
-      description="Text describing how the calories relate to the walking and biking duration of a trip."
-      id="otpUi.TripDetails.caloriesDescription"
-      values={{
-        bikeMinutes: Math.round(bikeSeconds / 60),
-        calories: Math.round(calories),
-        dietaryLink,
-        strong: boldText,
-        walkMinutes: Math.round(walkSeconds / 60)
-      }}
-    />
   );
 }
 
@@ -111,13 +66,11 @@ const TransitFare = ({
 };
 
 /**
- * Renders trip details such as departure instructions, fare amount, and calories spent.
+ * Renders trip details such as departure instructions and fare amount.
  */
 export function TripDetails({
-  CaloriesDetails = DefaultCaloriesDetails,
   className = "",
   defaultFareKey = "regular",
-  displayCalories = true,
   DepartureDetails = null,
   FareDetails = null,
   fareDetailsLayout,
@@ -218,13 +171,6 @@ export function TripDetails({
 
   const departureDate = new Date(itinerary.startTime);
 
-  // Compute calories burned.
-  const {
-    bikeDuration,
-    caloriesBurned,
-    walkDuration
-  } = coreUtils.itinerary.calculatePhysicalActivity(itinerary);
-
   // Calculate CO₂ if it's not provided by the itinerary
   const co2 =
     itinerary.co2 ||
@@ -295,33 +241,6 @@ export function TripDetails({
             }
             icon={<MoneyBillAlt size={17} />}
             summary={fare}
-          />
-        )}
-        {displayCalories && caloriesBurned > 0 && (
-          <TripDetail
-            icon={<Heartbeat size={17} />}
-            summary={
-              <S.CaloriesSummary>
-                <FormattedMessage
-                  defaultMessage={defaultMessages["otpUi.TripDetails.calories"]}
-                  description="Text showing the number of calories for the walking and biking legs of a trip."
-                  id="otpUi.TripDetails.calories"
-                  values={{
-                    calories: caloriesBurned,
-                    strong: boldText
-                  }}
-                />
-              </S.CaloriesSummary>
-            }
-            description={
-              CaloriesDetails && (
-                <CaloriesDetails
-                  bikeSeconds={bikeDuration}
-                  calories={caloriesBurned}
-                  walkSeconds={walkDuration}
-                />
-              )
-            }
           />
         )}
         {co2 > 0 && co2Config?.enabled && (

--- a/packages/trip-details/src/styled.ts
+++ b/packages/trip-details/src/styled.ts
@@ -17,10 +17,6 @@ const BaseButton = styled.button`
   white-space: nowrap;
 `;
 
-export const CaloriesDescription = styled.span``;
-
-export const CaloriesSummary = styled.span``;
-
 export const CO2Description = styled.span``;
 
 export const CO2Summary = styled.span``;

--- a/packages/trip-details/src/types.ts
+++ b/packages/trip-details/src/types.ts
@@ -3,11 +3,6 @@
 import type { MassUnitOption, Fare, Itinerary, Money } from "@opentripplanner/types";
 import type { ReactElement } from "react";
 
-export interface CaloriesDetailsProps {
-  bikeSeconds: number;
-  calories: number;
-  walkSeconds: number;
-}
 
 export interface CO2ConfigType {
   carbonIntensity?: Record<string, number>;
@@ -63,10 +58,6 @@ export interface TransitFareProps {
 
 export interface TripDetailsProps {
   /**
-   * Slot for a custom component to render the expandable section for calories.
-   */
-  CaloriesDetails?: React.ElementType<CaloriesDetailsProps>;
-  /**
    * Used for additional styling with styled components for example.
    */
   className?: string;
@@ -78,11 +69,6 @@ export interface TripDetailsProps {
    * Slot for a custom component to render the expandable section for departure.
    */
   DepartureDetails?: React.ElementType<DepartureDetailsProps>;
-  /**
-   * If this is set to true, a row will be added to the trip details displaying how
-   * many calories were burned on the active legs of the trip.
-   */
-  displayCalories?: boolean;
   /**
    * Slot for a custom component to render the expandable section for fares.
    */


### PR DESCRIPTION
Fully removes calorie counts, associated methods, and i18n strings. 

Potentially replaced by "steps" or "minutes active" down the line.