### PR TITLE
fix(core-utils): fix duplicate gtfsId

### DIFF
--- a/packages/core-utils/src/planQuery.graphql
+++ b/packages/core-utils/src/planQuery.graphql
@@ -157,8 +157,8 @@ query Plan(
             id
           }
           color
-          gtfsId: id
           gtfsId
+          id
           longName
           shortName
           textColor


### PR DESCRIPTION
Seems like a merge error caused a duplicate gtfsId in the planQuery